### PR TITLE
completed hw5

### DIFF
--- a/h2/src/main/org/h2/command/query/Optimizer.java
+++ b/h2/src/main/org/h2/command/query/Optimizer.java
@@ -82,7 +82,9 @@ class Optimizer {
         } else {
             startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
-                calculateBruteForceAll(isSelectCommand);
+                RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(session, filters);
+                TableFilter[] ruleBasedResult = ruleBasedJoinOrderPicker.bestOrder();
+                testPlan(ruleBasedResult, isSelectCommand);
             } else {
                 calculateBruteForceSome(isSelectCommand);
                 random = new Random(0);

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -1,0 +1,113 @@
+package org.h2.command.query;
+
+import java.util.*;
+import org.h2.table.TableFilter;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+
+
+public class RuleBasedJoinOrderPicker {
+    final SessionLocal currentSession;
+    final TableFilter[] filters;
+
+    // instance constructor
+    public RuleBasedJoinOrderPicker(SessionLocal session, TableFilter[] filters) {
+        this.currentSession = session;
+        this.filters = filters;
+    }
+
+    public TableFilter[] bestOrder() {
+        Map<TableFilter, List<TableFilter>> connectionGraph = buildConnectionGraph();
+        Optional<TableFilter> initialFilter = selectInitialFilter();
+        List<TableFilter> optimalOrder = new ArrayList<>();
+        
+        // traverse the graph to get to best join order
+        initialFilter.ifPresent(filter -> 
+            getOrder(filter, connectionGraph, optimalOrder, new HashSet<>()));
+        
+        return optimalOrder.toArray(new TableFilter[0]);
+    }
+
+    private Map<TableFilter, List<TableFilter>> buildConnectionGraph() {
+        Map<TableFilter, List<TableFilter>> connectionGraph = new HashMap<>();
+        Set<Expression> processedConditions = new HashSet<>();
+
+        for (TableFilter filter : filters) {
+            connectionGraph.put(filter, new ArrayList<>());
+            Expression condition = filter.getFullCondition();
+            
+            // establish the connnections for each unique condition
+            if (condition != null && !processedConditions.contains(condition)) {
+                addConnections(condition, connectionGraph);
+                processedConditions.add(condition);
+            }
+        }
+        return connectionGraph;
+    }
+
+    private void addConnections(Expression expr, Map<TableFilter, List<TableFilter>> graph) {
+        if (expr instanceof ConditionAndOr || expr instanceof ConditionAndOrN) {
+            // process for AND/OR conditions
+            for (int i = 0; i < expr.getSubexpressionCount(); i++) {
+                addConnections(expr.getSubexpression(i), graph);
+            }
+        } else if (expr instanceof Comparison) {
+            Expression leftExpr = expr.getSubexpression(0);
+            Expression rightExpr = expr.getSubexpression(1);
+    
+            if (leftExpr instanceof ExpressionColumn && rightExpr instanceof ExpressionColumn) {
+                TableFilter leftFilter = ((ExpressionColumn) leftExpr).getTableFilter();
+                TableFilter rightFilter = ((ExpressionColumn) rightExpr).getTableFilter();
+    
+                if (isValidConnection(leftFilter, rightFilter)) {
+                    createBidirectionalLink(leftFilter, rightFilter, graph);
+                }
+            }
+        }
+    }
+
+    private boolean isValidConnection(TableFilter f1, TableFilter f2) {
+        return f1 != null && f2 != null && f1 != f2;
+    }
+
+    private void createBidirectionalLink(TableFilter src, TableFilter dest, 
+                                        Map<TableFilter, List<TableFilter>> graph) {
+        addUniqueConnection(src, dest, graph);
+        addUniqueConnection(dest, src, graph);
+    }
+
+    private void addUniqueConnection(TableFilter source, TableFilter target, 
+                                    Map<TableFilter, List<TableFilter>> graph) {
+        if (!graph.get(source).contains(target)) {
+            graph.get(source).add(target);
+        }
+    }
+
+    private Optional<TableFilter> selectInitialFilter() {
+        return Arrays.stream(filters)
+            .min(Comparator.comparingLong(f -> 
+                f.getTable().getRowCountApproximation(currentSession)));
+    }
+
+    private void getOrder(TableFilter currentFilter, Map<TableFilter, List<TableFilter>> graph, List<TableFilter> order,
+            Set<TableFilter> visited) {
+        visited.add(currentFilter);
+        order.add(currentFilter);
+
+        // sortby row count
+        graph.getOrDefault(currentFilter, Collections.emptyList())
+            .stream()
+            .sorted(Comparator.comparingLong(f -> 
+                f.getTable().getRowCountApproximation(currentSession)))
+            .forEach(neighbor -> {
+                if (!visited.contains(neighbor)) {
+                    getOrder(neighbor, graph, order, visited);
+                }
+            });
+    }
+
+}

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1252,6 +1252,10 @@ public class TableFilter implements ColumnResolver {
         return indexHints;
     }
 
+    public Expression getFullCondition(){
+        return fullCondition;
+    }
+
     /**
      * Returns whether this is a table filter with implicit DUAL table for a
      * SELECT without a FROM clause.


### PR DESCRIPTION
## Query from HW 4 Problem 4 
 
![Screenshot 2025-03-29 225627](https://github.com/user-attachments/assets/a10e5a48-1422-4628-ac2b-1de80817a2db)

The rule based join order optimizer selects users, followers, then posts. It performs significantly better.
 
## HW 5 : Query 1 - Single Table
 
![Screenshot 2025-03-29 230859](https://github.com/user-attachments/assets/df9c8a27-51df-4987-b1e9-916e04a15946)
 
 This query is a simple select all query, meaning my rule-based optimizer doesn't need to make any decisions since there's only one table involved.
 
## HW 5 : Query 2 - Just Two Tables
 
![Screenshot 2025-03-29 231753](https://github.com/user-attachments/assets/7c8ae66b-75a2-4e75-8b27-0956715453a1)
 
 The optimizer selects customers, then orders. This is optimal because it start wwith the smaller table, and it correctly builds the connection graph and follows the join path.
 
## HW 5 : Query 3 - Three Tables
 
![Screenshot 2025-03-29 231832](https://github.com/user-attachments/assets/8af97e5b-1ec8-46ff-940b-432c15a08e3c)
 
 The optimizer selects products, order_details, then orders. The optimizer's connection graph correctly identifies the relationships between tables.
 
## HW 5 : Query 4 - Four Tables

![Screenshot 2025-03-29 231849](https://github.com/user-attachments/assets/e7d68aba-17c8-44d0-b1ae-f3877f013e50)
 
The optimizer selects customers, orders, order_details, then products.
 
## HW 5 : Query 5 - Five Tables
 
![Screenshot 2025-03-29 231924](https://github.com/user-attachments/assets/6fc2de6a-372d-44b9-9782-fcd2d58a5c76)
 
The optimizer selects customers,orders, order_details, products, then suppliers.
 
## HW 5 : Query 6 - Four Tables, More Options
 
![Screenshot 2025-03-29 231947](https://github.com/user-attachments/assets/202f33ab-b6f5-46a3-adfd-1b2687b0e5a8)
 
The optimizer selects products, order_details, order_payments, then orders.
 
## Our rule based optimizer is still fairly limited.  Can you think of a query in which it would perform a fairly catastrophic join order?
 
The optimizer could perform poorly when there is a selective predicate on larger tables; for example, if orders has a where clause, then the optimizer would still choose the smaller table. In addition, the optimizer does not handle subqueries.
 
## Our rule based optimizer is still fairly limited.  If you were to improve it, what additional rules would you include?

Filter selectivity, being aware of indexes, taking account of join types, memory constraints.

